### PR TITLE
Adding support for comparing object files of the generated app

### DIFF
--- a/Comparer.cs
+++ b/Comparer.cs
@@ -106,12 +106,9 @@ class Comparer {
 	{
 		DirectoryInfo Directory1 = new (app1path);
 		if (Directory1.Exists) {
-			var len1 = app1path.Length;
-			if (app1path [len1 - 1] != Path.DirectorySeparatorChar)
-				len1++;
 			foreach (var file in Directory1.GetFiles (filter, SearchOption.AllDirectories)) {
 				dt.Rows.Add (new object? [] {
-					file.FullName [len1..],
+					file.Name,
 					(file, file.Length),
 					empty,
 					-file.Length,
@@ -125,11 +122,8 @@ class Comparer {
 		if (!Directory2.Exists)
 			return;
 
-		var len2 = app2path.Length;
-		if (app2path [len2 - 1] != Path.DirectorySeparatorChar)
-			len2++;
 		foreach (var file in Directory2.GetFiles (filter, SearchOption.AllDirectories)) {
-			var name = file.FullName [len2..];
+			var name = file.Name;
 			var row = dt.Rows.Find (name);
 			var remapped = false;
 			if (row is null) {

--- a/Comparer.cs
+++ b/Comparer.cs
@@ -9,7 +9,7 @@ class Comparer {
 
 	const string FILTER_ALL_FILES = "*.*";
 
-	public static DataTable GetTable (string app1path, string app2path, Dictionary<string, string> mappings)
+	public static DataTable GetTable (string app1path, string app2path, Dictionary<string, string> mappings, string? obj1path = null, string? obj2path = null)
 	{
 		DataTable dt = new ();
 		DataColumn files = new ("Files", typeof (string));

--- a/Comparer.cs
+++ b/Comparer.cs
@@ -8,6 +8,7 @@ namespace AppCompare;
 class Comparer {
 
 	const string FILTER_ALL_FILES = "*.*";
+	const string FILTER_OBJ_FILES = "*.o";
 
 	public static DataTable GetAppCompareTable (string app1path, string app2path, Dictionary<string, string> mappings)
 	{
@@ -99,6 +100,35 @@ class Comparer {
 			AddSummaryRow (dt, "Managed *.dll/exe", managed_a, managed_b);
 		AddEmptyRow (dt);
 		AddSummaryRow (dt, "TOTAL", size_a, size_b);
+
+		return dt;
+	}
+
+	public static DataTable GetObjCompareTable (string app1path, string app2path, Dictionary<string, string> mappings)
+	{
+		DataTable dt = new ("Object files compare");
+		DataColumn files = new ("Files", typeof (string));
+		dt.Columns.Add (files);
+		dt.PrimaryKey = new [] { files };
+
+		dt.Columns.Add (new DataColumn ("Size A", typeof ((FileInfo, long))));
+		dt.Columns.Add (new DataColumn ("Size B", typeof ((FileInfo, long))));
+		dt.Columns.Add (new DataColumn ("diff", typeof (long)));
+		dt.Columns.Add (new DataColumn ("%", typeof (double)));
+		dt.Columns.Add (new DataColumn (" ", typeof (string)));
+
+		try {
+			Populate (dt, app1path, app2path, mappings, FILTER_OBJ_FILES);
+		} catch (Exception ex) {
+			dt.ExtendedProperties.Add ("Exception", ex);
+		}
+
+		dt.DefaultView.Sort = "Files ASC";
+		dt = dt.DefaultView.ToTable ();
+		dt.ExtendedProperties.Add ("AppA", app1path);
+		dt.ExtendedProperties.Add ("AppB", app2path);
+
+		AddEmptyRow (dt);
 		return dt;
 	}
 

--- a/Comparer.cs
+++ b/Comparer.cs
@@ -7,8 +7,8 @@ namespace AppCompare;
 
 class Comparer {
 
-	const string FILTER_ALL_FILES = "*.*";
-	const string FILTER_OBJ_FILES = "*.o";
+	const string filter_all_files = "*.*";
+	const string filter_obj_files = "*.o";
 
 	public static DataTable GetAppCompareTable (string app1path, string app2path, Dictionary<string, string> mappings)
 	{
@@ -24,7 +24,7 @@ class Comparer {
 		dt.Columns.Add (new DataColumn (" ", typeof (string)));
 
 		try {
-			Populate (dt, app1path, app2path, mappings, FILTER_ALL_FILES);
+			Populate (dt, app1path, app2path, mappings, filter_all_files);
 		} catch (Exception ex) {
 			dt.ExtendedProperties.Add ("Exception", ex);
 		}
@@ -118,7 +118,7 @@ class Comparer {
 		dt.Columns.Add (new DataColumn (" ", typeof (string)));
 
 		try {
-			Populate (dt, app1path, app2path, mappings, FILTER_OBJ_FILES);
+			Populate (dt, app1path, app2path, mappings, filter_obj_files);
 		} catch (Exception ex) {
 			dt.ExtendedProperties.Add ("Exception", ex);
 		}

--- a/Comparer.cs
+++ b/Comparer.cs
@@ -7,6 +7,8 @@ namespace AppCompare;
 
 class Comparer {
 
+	const string FILTER_ALL_FILES = "*.*";
+
 	public static DataTable GetTable (string app1path, string app2path, Dictionary<string, string> mappings)
 	{
 		DataTable dt = new ();
@@ -21,7 +23,7 @@ class Comparer {
 		dt.Columns.Add (new DataColumn (" ", typeof (string)));
 
 		try {
-			Populate (dt, app1path, app2path, mappings);
+			Populate (dt, app1path, app2path, mappings, FILTER_ALL_FILES);
 		} catch (Exception ex) {
 			dt.ExtendedProperties.Add ("Exception", ex);
 		}
@@ -100,14 +102,14 @@ class Comparer {
 		return dt;
 	}
 
-	static void Populate (DataTable dt, string app1path, string app2path, Dictionary<string, string> mappings)
+	static void Populate (DataTable dt, string app1path, string app2path, Dictionary<string, string> mappings, string filter)
 	{
 		DirectoryInfo Directory1 = new (app1path);
 		if (Directory1.Exists) {
 			var len1 = app1path.Length;
 			if (app1path [len1 - 1] != Path.DirectorySeparatorChar)
 				len1++;
-			foreach (var file in Directory1.GetFiles ("*.*", SearchOption.AllDirectories)) {
+			foreach (var file in Directory1.GetFiles (filter, SearchOption.AllDirectories)) {
 				dt.Rows.Add (new object? [] {
 					file.FullName [len1..],
 					(file, file.Length),
@@ -126,7 +128,7 @@ class Comparer {
 		var len2 = app2path.Length;
 		if (app2path [len2 - 1] != Path.DirectorySeparatorChar)
 			len2++;
-		foreach (var file in Directory2.GetFiles ("*.*", SearchOption.AllDirectories)) {
+		foreach (var file in Directory2.GetFiles (filter, SearchOption.AllDirectories)) {
 			var name = file.FullName [len2..];
 			var row = dt.Rows.Find (name);
 			var remapped = false;

--- a/Program.cs
+++ b/Program.cs
@@ -12,8 +12,9 @@ class Program {
 	/// <param name="outputMarkdown">Filename for the markdown output (optional).</param>
 	/// <param name="gist">Gist the output.</param>
 	/// <param name="mappingFile">File that describe a custom mapping between files from both application bundles/directories.</param>
+	/// <param name="objDirs">Pair of directories for scanning for object files, separated with a semicolon (optional)</param>
 	/// <returns>0 for success, 1 for invalid/incorrect arguments, 2 for unexpected failure.</returns>
-	static int Main (string [] args, string? outputMarkdown, bool gist, string mappingFile)
+	static int Main (string [] args, string? outputMarkdown, bool gist, string mappingFile, string? objDirs)
 	{
 		try {
 			Dictionary<string, string>? mappings = null;
@@ -57,7 +58,22 @@ class Program {
 				return 1;
 			}
 
-			var table = Comparer.GetTable (app1, app2, mappings);
+			string? objDir1 = null;
+			string? objDir2 = null;
+			if (!string.IsNullOrEmpty(objDirs)) {
+				var objDirsSplitted = objDirs.Split(";");
+
+				if (!CheckDirectory (objDirsSplitted[0], out objDir1)) {
+					AnsiConsole.MarkupLine ($"[red]Error:[/] Cannot find obj or directory at `{objDir1}`.");
+					return 1;
+				}
+				if (!CheckDirectory (objDirsSplitted[1], out objDir2)) {
+					AnsiConsole.MarkupLine ($"[red]Error:[/] Cannot find obj or directory at `{objDir2}`.");
+					return 1;
+				}
+			}
+
+			var table = Comparer.GetTable (app1, app2, mappings, objDir1, objDir2);
 			string markdown = Comparer.ExportMarkdown (table);
 
 			if (outputMarkdown is not null) {

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 using Spectre.Console;
 using Terminal.Gui;
+using System.Data;
 
 namespace AppCompare;
 
@@ -18,6 +19,7 @@ class Program {
 	{
 		try {
 			Dictionary<string, string>? mappings = null;
+			List<DataTable> tables = new List<DataTable>();
 
 			// if mappings are given then they must exists
 			if (mappingFile is not null) {
@@ -58,6 +60,8 @@ class Program {
 				return 1;
 			}
 
+			tables.Add(Comparer.GetAppCompareTable (app1, app2, mappings));
+
 			string? objDir1 = null;
 			string? objDir2 = null;
 			if (!string.IsNullOrEmpty(objDirs)) {
@@ -73,15 +77,13 @@ class Program {
 				}
 			}
 
-			var table = Comparer.GetTable (app1, app2, mappings, objDir1, objDir2);
-			string markdown = Comparer.ExportMarkdown (table);
-
+			string markdown = Comparer.ExportMarkdown (tables);
 			if (outputMarkdown is not null) {
 				File.WriteAllText (outputMarkdown, markdown);
 			}
 
 			if (gist) {
-				var url = Comparer.Gist (table, openUrl: false);
+				var url = Comparer.Gist (tables, openUrl: false);
 				Console.Out.WriteLine (url);
 			}
 

--- a/Program.cs
+++ b/Program.cs
@@ -13,7 +13,7 @@ class Program {
 	/// <param name="outputMarkdown">Filename for the markdown output (optional).</param>
 	/// <param name="gist">Gist the output.</param>
 	/// <param name="mappingFile">File that describe a custom mapping between files from both application bundles/directories.</param>
-	/// <param name="objDirs">Pair of directories for scanning for object files, separated with a semicolon (optional)</param>
+	/// <param name="objDirs">Pair of directories for scanning for object files, separated with a colon (optional)</param>
 	/// <returns>0 for success, 1 for invalid/incorrect arguments, 2 for unexpected failure.</returns>
 	static int Main (string [] args, string? outputMarkdown, bool gist, string mappingFile, string? objDirs)
 	{
@@ -64,8 +64,9 @@ class Program {
 
 			string? objDir1 = null;
 			string? objDir2 = null;
+
 			if (!string.IsNullOrEmpty(objDirs)) {
-				var objDirsSplitted = objDirs.Split(";");
+				var objDirsSplitted = objDirs.Split(":");
 
 				if (!CheckDirectory (objDirsSplitted[0], out objDir1)) {
 					AnsiConsole.MarkupLine ($"[red]Error:[/] Cannot find obj or directory at `{objDir1}`.");

--- a/Program.cs
+++ b/Program.cs
@@ -75,6 +75,7 @@ class Program {
 					AnsiConsole.MarkupLine ($"[red]Error:[/] Cannot find obj or directory at `{objDir2}`.");
 					return 1;
 				}
+				tables.Add(Comparer.GetObjCompareTable (objDir1, objDir2, mappings));
 			}
 
 			string markdown = Comparer.ExportMarkdown (tables);

--- a/Program.cs
+++ b/Program.cs
@@ -67,13 +67,16 @@ class Program {
 
 			if (!string.IsNullOrEmpty(objDirs)) {
 				var objDirsSplitted = objDirs.Split(":");
-
+				if (objDirsSplitted.Length != 2) {
+					AnsiConsole.MarkupLine ($"[red]Error:[/] Missing or invalid path to obj directories.");
+					return 1;
+				}
 				if (!CheckDirectory (objDirsSplitted[0], out objDir1)) {
-					AnsiConsole.MarkupLine ($"[red]Error:[/] Cannot find obj or directory at `{objDir1}`.");
+					AnsiConsole.MarkupLine ($"[red]Error:[/] Cannot find obj directory at `{objDir1}`.");
 					return 1;
 				}
 				if (!CheckDirectory (objDirsSplitted[1], out objDir2)) {
-					AnsiConsole.MarkupLine ($"[red]Error:[/] Cannot find obj or directory at `{objDir2}`.");
+					AnsiConsole.MarkupLine ($"[red]Error:[/] Cannot find obj directory at `{objDir2}`.");
 					return 1;
 				}
 				tables.Add(Comparer.GetObjCompareTable (objDir1, objDir2, mappings));

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,6 @@
+using System.Data;
 using Spectre.Console;
 using Terminal.Gui;
-using System.Data;
 
 namespace AppCompare;
 
@@ -19,7 +19,7 @@ class Program {
 	{
 		try {
 			Dictionary<string, string>? mappings = null;
-			List<DataTable> tables = new List<DataTable>();
+			List<DataTable> tables = new List<DataTable> ();
 
 			// if mappings are given then they must exists
 			if (mappingFile is not null) {
@@ -60,26 +60,26 @@ class Program {
 				return 1;
 			}
 
-			tables.Add(Comparer.GetAppCompareTable (app1, app2, mappings));
+			tables.Add (Comparer.GetAppCompareTable (app1, app2, mappings));
 
 			string? objDir1 = null;
 			string? objDir2 = null;
 
-			if (!string.IsNullOrEmpty(objDirs)) {
-				var objDirsSplitted = objDirs.Split(":");
+			if (!string.IsNullOrEmpty (objDirs)) {
+				var objDirsSplitted = objDirs.Split (":");
 				if (objDirsSplitted.Length != 2) {
 					AnsiConsole.MarkupLine ($"[red]Error:[/] Missing or invalid path to obj directories.");
 					return 1;
 				}
-				if (!CheckDirectory (objDirsSplitted[0], out objDir1)) {
+				if (!CheckDirectory (objDirsSplitted [0], out objDir1)) {
 					AnsiConsole.MarkupLine ($"[red]Error:[/] Cannot find obj directory at `{objDir1}`.");
 					return 1;
 				}
-				if (!CheckDirectory (objDirsSplitted[1], out objDir2)) {
+				if (!CheckDirectory (objDirsSplitted [1], out objDir2)) {
 					AnsiConsole.MarkupLine ($"[red]Error:[/] Cannot find obj directory at `{objDir2}`.");
 					return 1;
 				}
-				tables.Add(Comparer.GetObjCompareTable (objDir1, objDir2, mappings));
+				tables.Add (Comparer.GetObjCompareTable (objDir1, objDir2, mappings));
 			}
 
 			string markdown = Comparer.ExportMarkdown (tables);

--- a/ProgramUI.cs
+++ b/ProgramUI.cs
@@ -174,7 +174,7 @@ class ProgramUI {
 		using SaveDialog d = new ("Export Table", "", new () { ".md" });
 		Application.Run (d);
 		if (!d.Canceled && (d.FilePath is not null)) {
-			File.WriteAllText (d.FilePath.ToString ()!, Comparer.ExportMarkdown (tv.Table));
+			File.WriteAllText (d.FilePath.ToString ()!, Comparer.ExportMarkdown (new List<DataTable>{tv.Table}));
 		}
 	}
 
@@ -239,13 +239,13 @@ class ProgramUI {
 
 	static void ViewGist ()
 	{
-		Comparer.Gist (tv.Table);
+		Comparer.Gist (new List<DataTable> {tv.Table});
 	}
 
 	static void ViewRefresh ()
 	{
 		if ((app1_path is not null) && (app2_path is not null)) {
-			tv.Table = Comparer.GetTable (app1_path, app2_path, mappings);
+			tv.Table = Comparer.GetAppCompareTable (app1_path, app2_path, mappings);
 			if (tv.Table.ExtendedProperties ["Exception"] is Exception ex) {
 				MessageBox.ErrorQuery (60, 13, "Error", ex.ToString (), "_Ok");
 			}

--- a/ProgramUI.cs
+++ b/ProgramUI.cs
@@ -174,7 +174,7 @@ class ProgramUI {
 		using SaveDialog d = new ("Export Table", "", new () { ".md" });
 		Application.Run (d);
 		if (!d.Canceled && (d.FilePath is not null)) {
-			File.WriteAllText (d.FilePath.ToString ()!, Comparer.ExportMarkdown (new List<DataTable>{tv.Table}));
+			File.WriteAllText (d.FilePath.ToString ()!, Comparer.ExportMarkdown (new List<DataTable> { tv.Table }));
 		}
 	}
 
@@ -239,7 +239,7 @@ class ProgramUI {
 
 	static void ViewGist ()
 	{
-		Comparer.Gist (new List<DataTable> {tv.Table});
+		Comparer.Gist (new List<DataTable> { tv.Table });
 	}
 
 	static void ViewRefresh ()


### PR DESCRIPTION
In order to get better insight into app size comparison as discussed https://github.com/xamarin/xamarin-macios/issues/10249#issuecomment-1154167714.
I have added an additional table generation which breaks down object files sizes and compares them accordingly.

The following has been done:
- A new command line switch has been introduced `--obj-dirs`
    - usage: `--obj-dirs abspath1:abspath2`
- `GetTable` has two versions: one for the app files and the other for the obj files table generation
    - filenames are now stored in the table without the relative path to the app or obj directories (this could potentially introduce problems with files with the same name across different sub directories)
- `ExportMarkdown` and `Gist` now accepts list of tables and generate reports in the new format (every table in its separate subsection)

Future work:
- Include obj files comparison feature into the GUI variant
- Refactor common code (for example `GetTable` method)
- Iron out command line switches
    - idea:
    ```
    appcompare /
    --app1 abspath_to_app:abspath_to_obj /
    --app2 abspath_to_app:abspath_to_obj /
    --obj-dirs true
    ```
    and
    ```
    appcompare /
    --app1 abspath_to_app /
    --app2 abspath_to_app
    ``` 
    - this way it would be more natural to match the paths to app and obj dirs, if --obj-dirs is leftout or `false` then the `abspath_to_obj` could be omitted
    
This is how the new report looks like:
https://gist.github.com/ivanpovazan/f9bb4e05cb2f6291b6c2318b3dacf22f