### PR TITLE
Fix first character in filenames.

### DIFF
--- a/Comparer.cs
+++ b/Comparer.cs
@@ -138,7 +138,7 @@ class Comparer {
 		if (Directory1.Exists) {
 			foreach (var file in Directory1.GetFiles (filter, SearchOption.AllDirectories)) {
 				dt.Rows.Add (new object? [] {
-					file.FullName[app1path.Length..],
+					file.FullName[(app1path.Trim (Path.DirectorySeparatorChar).Length + 2)..],
 					(file, file.Length),
 					empty,
 					-file.Length,
@@ -153,7 +153,7 @@ class Comparer {
 			return;
 
 		foreach (var file in Directory2.GetFiles (filter, SearchOption.AllDirectories)) {
-			var name = file.FullName[app2path.Length..];
+			var name = file.FullName[(app2path.Trim (Path.DirectorySeparatorChar).Length + 2)..];
 			var row = dt.Rows.Find (name);
 			var remapped = false;
 			if (row is null) {


### PR DESCRIPTION
This fixes an issue where the file mapping didn't work anymore.

Exmaple: https://gist.github.com/rolfbjarne/0a3c75a43d7562878cb9c6bdf81703d6

Microsoft.iOS.dll was supposed to be mapped to Xamarin.iOS.dll.

It also removes an initial slash for every file in the file listing.